### PR TITLE
Fix annual pricing redirect issue

### DIFF
--- a/src/app/api/stripe/create-signup-checkout/route.ts
+++ b/src/app/api/stripe/create-signup-checkout/route.ts
@@ -7,7 +7,7 @@ const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
 
 export async function POST(request: NextRequest) {
   try {
-    const { email, fullName, gradeLevel } = await request.json()
+    const { email, fullName, gradeLevel, plan } = await request.json()
 
     if (!email || !fullName || !gradeLevel) {
       return NextResponse.json(
@@ -17,17 +17,19 @@ export async function POST(request: NextRequest) {
     }
 
     // Get the price ID from environment variables based on plan
-    const priceId = process.env.NEXT_PUBLIC_STRIPE_PRICE_MONTHLY
+    const priceId = plan === 'annual' 
+      ? process.env.NEXT_PUBLIC_STRIPE_PRICE_ANNUAL
+      : process.env.NEXT_PUBLIC_STRIPE_PRICE_MONTHLY
     
     if (!priceId) {
-      console.error('Stripe price ID not configured. Expected NEXT_PUBLIC_STRIPE_PRICE_MONTHLY')
+      console.error(`Stripe price ID not configured for ${plan} plan. Expected NEXT_PUBLIC_STRIPE_PRICE_${plan.toUpperCase()}`)
       return NextResponse.json(
         { error: 'Payment configuration error. Price ID not found.' },
         { status: 500 }
       )
     }
 
-    console.log('Creating checkout session with price ID:', priceId)
+    console.log(`Creating checkout session for ${plan} plan with price ID:`, priceId)
 
     // Create checkout session with metadata for account creation
     const session = await stripe.checkout.sessions.create({

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -50,9 +50,9 @@ export default function PricingPage() {
   // Check if Stripe is configured
   const isStripeConfigured = !!(STRIPE_CONFIG.prices.monthly && STRIPE_CONFIG.prices.annual)
 
-  const handleSelectPlan = async (priceId: string) => {
+  const handleSelectPlan = async (priceId: string, planName: string) => {
     if (!user) {
-      router.push('/signup')
+      router.push(`/signup?plan=${planName.toLowerCase()}`)
       return
     }
 
@@ -202,7 +202,7 @@ NEXT_PUBLIC_STRIPE_PRICE_ANNUAL=price_xxxxx`}</code>
                     subscription,
                     priceId: plan.priceId
                   })
-                  handleSelectPlan(plan.priceId!)
+                  handleSelectPlan(plan.priceId!, plan.name)
                 }}
                 disabled={!isStripeConfigured || loading !== null || subscriptionLoading || (subscription?.tier === 'premium' && !subscription.cancelAtPeriodEnd)}
                 className={`w-full py-3 px-4 rounded-lg font-semibold transition-colors ${

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -71,6 +71,9 @@ export default function SignupPage() {
         gradeLevel: formData.gradeLevel,
       }))
 
+      // Get the plan from URL params (default to monthly if not specified)
+      const plan = searchParams.get('plan') || 'monthly'
+
       // Create Stripe checkout session
       const response = await fetch('/api/stripe/create-signup-checkout', {
         method: 'POST',
@@ -81,6 +84,7 @@ export default function SignupPage() {
           email: formData.email,
           fullName: formData.fullName,
           gradeLevel: formData.gradeLevel,
+          plan: plan,
         }),
       })
 

--- a/tests/pricing-flow.spec.ts
+++ b/tests/pricing-flow.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Pricing Flow', () => {
+  test('should redirect to signup with monthly plan parameter', async ({ page }) => {
+    // Navigate to pricing page
+    await page.goto('/pricing')
+    
+    // Find and click the monthly plan button
+    const monthlyButton = page.locator('button:has-text("Get Started")').first()
+    await monthlyButton.click()
+    
+    // Should redirect to signup with monthly plan parameter
+    await expect(page).toHaveURL('/signup?plan=monthly')
+  })
+
+  test('should redirect to signup with annual plan parameter', async ({ page }) => {
+    // Navigate to pricing page
+    await page.goto('/pricing')
+    
+    // Find and click the annual plan button
+    const annualButton = page.locator('button:has-text("Get Started")').nth(1)
+    await annualButton.click()
+    
+    // Should redirect to signup with annual plan parameter
+    await expect(page).toHaveURL('/signup?plan=annual')
+  })
+
+  test('signup page should maintain plan parameter through form submission', async ({ page }) => {
+    // Navigate directly to signup with annual plan
+    await page.goto('/signup?plan=annual')
+    
+    // Fill out the form
+    await page.fill('input[name="fullName"]', 'Test User')
+    await page.fill('input[name="email"]', 'test@example.com')
+    await page.fill('input[name="password"]', 'TestPassword123!')
+    await page.fill('input[name="confirmPassword"]', 'TestPassword123!')
+    
+    // Mock the API response
+    await page.route('/api/stripe/create-signup-checkout', async (route) => {
+      const request = route.request()
+      const postData = await request.postDataJSON()
+      
+      // Verify the plan parameter is passed correctly
+      expect(postData.plan).toBe('annual')
+      
+      // Return mock response
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          url: 'https://checkout.stripe.com/test',
+          sessionId: 'test-session-id'
+        })
+      })
+    })
+    
+    // Submit the form
+    await page.click('button[type="submit"]')
+    
+    // Wait for the API call
+    await page.waitForTimeout(1000)
+  })
+})


### PR DESCRIPTION
## Summary
- Fixed issue where clicking annual plan redirected to monthly subscription
- Added plan parameter to signup flow that gets passed through to Stripe checkout

## Changes
- Updated pricing page to include plan parameter in signup redirect
- Modified signup page to read plan parameter from URL and pass to API
- Updated create-signup-checkout API to select correct price ID based on plan parameter
- Added E2E tests to verify the flow works correctly

## Testing
- Created E2E tests that verify both monthly and annual plans redirect with correct parameters
- Verified plan parameter is passed through to the API correctly
- Build passes successfully

Fixes #8